### PR TITLE
corrects time setting in timer:advance() + tests

### DIFF
--- a/fibers/timer.lua
+++ b/fibers/timer.lua
@@ -123,6 +123,7 @@ function TimerHeap:advance(t, sched)
         self.now = node.time
         sched:schedule(node.obj)
     end
+    self.now = t
 end
 
 return {

--- a/tests/test_timer.lua
+++ b/tests/test_timer.lua
@@ -7,48 +7,90 @@ package.path = "../?.lua;" .. package.path
 local timer = require 'fibers.timer'
 local sc = require 'fibers.utils.syscall'
 
-local wheel = timer.new(10)
-
--- At millisecond precision, advancing the wheel by an hour shouldn't
--- take perceptible time.
-local hour = 60*60
-local start_time = sc.monotime()
-wheel:advance(hour)
-local end_time = sc.monotime()
-print("Time to advance wheel by an hour: "..(end_time - start_time).." seconds")
-
-local event_count = 1e4 -- Increase number of events for stress test
-local t = wheel.now
-start_time = sc.monotime()
-for _=1,event_count do
-    local dt = math.random()
-    t = t + dt
-    wheel:add_absolute(t, t) -- this is adding a simple number as the payload stored in the timer wheel
-end
-end_time = sc.monotime()
-print("Time to add "..event_count.." events: "..(end_time - start_time).." seconds")
-
-local last = 0
-local count = 0
-local check = {}
-function check:schedule(t) -- in the call to wheel:advance below, this method is called and provided the payload inserted into the wheel, if it were really a scheduler it would resume the coroutine stored in the wheel??
-    local now = wheel.now
-    -- The timer wheel only guarantees ordering between ticks, not
-    -- ordering within a tick.  It doesn't even guarantee insertion
-    -- order within a tick.  However for this test we know that
-    -- insertion order is preserved.
-    assert(last <= t)
-    last, count = t, count + 1
-    -- Check that timers fire when they should.  
-    assert(now - 1e-4 < t)
-    assert(t < now + 1e-4)
+local function test_advance_time()
+    local wheel = timer.new(10)
+    local hour = 60 * 60
+    local start_time = sc.monotime()
+    wheel:advance(hour)
+    local end_time = sc.monotime()
+    print("Time to advance wheel by an hour: "..(end_time - start_time).." seconds")
 end
 
-start_time = sc.monotime()
-wheel:advance(t+1, check)
-end_time = sc.monotime()
-print("Time to advance wheel to expire "..event_count.." events: "..(end_time - start_time).." seconds")
+local function test_event_scheduling(event_count)
+    local wheel = timer.new(sc.monotime())
+    local t = wheel.now
+    local start_time = sc.monotime()
+    for _=1, event_count do
+        local dt = math.random()
+        t = t + dt
+        wheel:add_absolute(t, t)
+    end
+    local end_time = sc.monotime()
+    print("Time to add "..event_count.." events: "..(end_time - start_time).." seconds")
+end
 
-assert(count == event_count)
+local function test_event_expiration(event_count)
+    local wheel = timer.new(sc.monotime())
+    local last = 0
+    local count = 0
+    local check = {}
+    local t = wheel.now
 
-print("test: ok")
+    function check:schedule(t)
+        local now = wheel.now
+        assert(last <= t)
+        last, count = t, count + 1
+        assert(now - 1e-3 < t)
+        assert(t < now + 1e-3)
+    end
+
+    for _=1, event_count do
+        local dt = math.random()
+        t = t + dt
+        wheel:add_absolute(t, t)
+    end
+
+    local start_time = sc.monotime()
+    wheel:advance(t + 1, check)
+    local end_time = sc.monotime()
+    print("Time to advance wheel to expire "..event_count.." events: "..(end_time - start_time).." seconds")
+    assert(count == event_count)
+end
+
+local function test_large_intervals()
+    local wheel = timer.new(sc.monotime())
+    local far_future = 1e6 -- Far future time
+    local event_triggered = false
+    wheel:add_absolute(wheel.now + far_future, 'far_future_event')
+    wheel:advance(wheel.now + far_future + 1e-3, {schedule = function() event_triggered = true end})
+    assert(event_triggered, "Far future event was not triggered")
+end
+
+local function test_small_intervals()
+    local wheel = timer.new(sc.monotime())
+    local very_near_future = 1e-6 -- Very near future time
+    local event_triggered = false
+    wheel:add_absolute(wheel.now + very_near_future, 'near_future_event')
+    wheel:advance(wheel.now + very_near_future + 1e-3, {schedule = function() event_triggered = true end})
+    assert(event_triggered, "Near future event was not triggered")
+end
+
+local function test_advance_now_update()
+    local wheel = timer.new(sc.monotime())
+    local advance_time = 100 -- Advance by 100 seconds
+    local start_time = wheel.now
+    wheel:advance(start_time + advance_time)
+    local expected_time = start_time + advance_time
+    assert(wheel.now == expected_time, "Advance method failed to update 'now' correctly")
+    print("Test for 'now' update in advance method passed")
+end
+
+-- Run tests
+test_advance_time()
+test_event_scheduling(1e4)
+test_event_expiration(1e4)
+test_large_intervals()
+test_small_intervals()
+test_advance_now_update()
+
+print("All tests passed")


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ x ] 🐛 Bug Fix

## Description

Fixes a small but subtle bug that was preventing the `:advance()` method from updating the `self.now` property of the timer.

## Manual test
- [ x ] 👍 yes

## Added tests?

- [ x ] 👍 yes

## Added to documentation?

- [ x ] 🙅 no documentation needed
