### PR TITLE
Implement Go-Like defer functionality in lua-fibers

### DIFF
--- a/examples/1-basic-usage/12-defer-multifiber.lua
+++ b/examples/1-basic-usage/12-defer-multifiber.lua
@@ -4,13 +4,13 @@ local fiber = require 'fibers.fiber'
 local channel = require 'fibers.channel'
 
 local defscope = fiber.defscope
-local defer = fiber.defer
 
 local res_chan = channel.new()
 
 local function first()
     local never_happens, happens = false, false
-    local test1 = defscope(function()
+    local defer, scope = defscope()
+    local test1 = scope(function()
         defer(function() happens = true end)
         defer(res_chan.put, res_chan, "A")
         defer(res_chan.put, res_chan, "B")
@@ -26,7 +26,8 @@ local function first()
 end
 
 local function second()
-    local test1 = defscope(function()
+    local defer, scope = defscope()
+    local test1 = scope(function()
         defer(res_chan.put, res_chan, "terminating")
         print(res_chan:get()) -- 'B' (defers done in reverse order)
         print(res_chan:get()) -- 'A'


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] 🍕 Feature

## Description

Introduces a defer functionality into the fibers framework, similar to what's found in Go. This featureenables the scheduling of functions to be executed when a certain scope exits, which is particularly useful for cleanup tasks and ensuring that resources are released properly, regardless of how the scope is exited (e.g., normal completion, error, or explicit exit). 

Key Features
- Scoped Defer Mechanism: Functions can now be deferred within a specific scope, ensuring they are executed in reverse order upon scope exit. This is particularly useful for resource cleanup and error handling.
- Robust Error Handling: Defer execution is integrated with fiber's error handling mechanism, ensuring deferred functions are called even if an error occurs within a fiber.
- Nested Scope Support: Allows for nested scopes within fibers, each with its own defer stack, enabling more complex and flexible task management.

## Screenshots/Recordings

## Manual test
- [X] 👍 yes
- [ ] 🙅 no

## Added tests?

- [X] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## [optional] Are there any post-deployment tasks we need to perform?

