### PR TITLE
fixed cancel signal being transferred to value ctx

### DIFF
--- a/fibers/context.lua
+++ b/fibers/context.lua
@@ -85,10 +85,16 @@ end
 -- @param any value The value to add.
 -- @return Context The new context.
 local function with_value(parent, key, value)
-    local ctx = setmetatable({
-        children = {},
-        values = setmetatable({[key] = value}, {__index = parent.values})
-    }, Context)
+    local ctx
+    if parent.cancel then
+        ctx = with_cancel(parent)
+        ctx.values[key] = value
+    else
+        ctx = setmetatable({
+            children = {},
+            values = setmetatable({[key] = value}, {__index = parent.values})
+        }, Context)
+    end
     return ctx
 end
 

--- a/tests/test.lua
+++ b/tests/test.lua
@@ -22,7 +22,8 @@ local modules = {
     {'pollio'},
     {'exec'},
     {'waitgroup'},
-    {'alarm'}
+    {'alarm'},
+    {'context'}
 }
 
 for _, j in ipairs(modules) do

--- a/tests/test_context.lua
+++ b/tests/test_context.lua
@@ -79,6 +79,18 @@ local function test_custom_cause()
     print("test_custom_cause passed")
 end
 
+local function test_cancel_on_with_value()
+    local parent = context.background()
+    local ctx, cancel = context.with_cancel(parent)
+    local ctx_2, _ = context.with_value(ctx, "key", "value")
+
+    cancel('cancelled')
+
+    assert(ctx:err() == 'cancelled', "Context should have cancel cause")
+    assert(ctx_2:err() == 'cancelled', "Child context should have cancel cause")
+    assert(ctx_2:value('key') == 'value', "Child context should have the value")
+end
+
 -- Run all tests
 fiber.spawn(function()
     test_background()
@@ -86,6 +98,7 @@ fiber.spawn(function()
     test_with_value()
     test_with_timeout()
     test_custom_cause()
+    test_cancel_on_with_value()
 
     print("All tests passed")
     fiber.stop()


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description
Previously if you had a context with cancel `ctx` and called `context.with_value(ctx)` the resulting context would not carry any cancel signal called by the parent ctx. This fix means a context that is already cancelable will pass that ability onto it's child context.

## Related Issues, Tickets & Documents
Fixes #33 

## Manual test
<!-- Have you manually tested this code and confirmed it is working? -->
- [x] 👍 yes
- [ ] 🙅 no

## Manual test description
`lua test_context.lua`

## Added tests?
- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?
- [ ] 📜 README.md
- [x] 🙅 no documentation needed


