### PR TITLE
Fix unsafe memory operations and improve LuaJIT compatibility in ring_buffer

### DIFF
--- a/fibers/utils/ring_buffer.lua
+++ b/fibers/utils/ring_buffer.lua
@@ -77,6 +77,10 @@ function buffer:advance_read(count)
     self.read_idx = to_uint32(self.read_idx + count)
 end
 
+function buffer:unadvance_read(count)
+    assert(count >= 0 and to_uint32(count) <= self.read_idx, "unadvance_read out of range")
+    self.read_idx = to_uint32(self.read_idx - count)
+end
 function buffer:write(bytes, count)
     assert(count and count >= 0, "invalid write count")
     assert(count <= self:write_avail(), 'write xrun')

--- a/fibers/utils/string_buffer.lua
+++ b/fibers/utils/string_buffer.lua
@@ -65,8 +65,7 @@ function str_buffer:next(n)
 end
 
 function str_buffer:unread_char()
-    -- for simplicity, we'll just advance the read index backward by 1
-    self.buf:advance_read(-1)
+    return self.buf:unadvance_read(1)
 end
 
 function str_buffer:grow(n)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [X] 🐛 Bug Fix

## Description

This change addresses several memory safety issues and compatibility concerns in the `ring_buffer` implementation when used with LuaJIT 2.1. Specifically, it resolves defects that could lead to segmentation faults or undefined behaviour in JIT-compiled code.

#### Summary of Changes:

* **Ensured safe memory copying**
  Replaced `ffi.copy` with `ffi.C.memmove` in `write`, `rewrite`, and `read` paths where source and destination ranges may overlap. This prevents undefined behaviour from aliasing during buffer wraparound.

* **Eliminated zero-length copy faults**
  Conditional logic added to avoid performing `ffi.copy` or `memmove` operations when `count == count1`, preventing use of one-past-end pointers which may fault on some platforms.

* **Restored wrap-safe 32-bit arithmetic**
  Reinstated fixed-width unsigned arithmetic for buffer indices using bitwise masking (`to_uint32`). Avoids loss of precision from FP arithmetic when counters exceed 2^53.

* **Added alignment padding for safe 64-bit access**
  Introduced a `uint32_t _pad` field in the `buffer_t` definition to enforce 8-byte alignment. This reduces the risk of alignment faults or illegal instruction traps on architectures requiring strict alignment (e.g. aarch64 on RPi 4).

* **Validated index movement**
  `advance_read` and `advance_write` now check that the count is within the valid range and do not allow negative wraparound or overshoot.

### Rationale:

These corrections ensure that the buffer remains safe and predictable in long-lived applications and under all LuaJIT configurations. The previous implementation, especially my changes from Wingo's original version, relied on behaviour not guaranteed by C and under JIT optimisation.

### Notes:

* No changes were made to external API or semantics; this is a safety and compatibility update only.

## Related Issues, Tickets & Documents

Might fix:
* https://github.com/jangala-dev/devicecode-lua/issues/40
* https://github.com/jangala-dev/devicecode-lua/issues/41


## Manual test
- [X] 👍 yes

## Manual test description
Our test suite continues to pass

## Added tests?
- [X] 🙅 no, because they aren't needed

## Added to documentation?
- [X] 🙅 no documentation needed

