### PR TITLE
Moves to LuaJIT v2.1.ROLLING for the devcontainer

### DIFF
--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -33,7 +33,9 @@ sudo cp cffi.so /usr/local/lib/lua/5.1/cffi.so
 cd /tmp
 git clone https://github.com/LuaJIT/LuaJIT
 cd LuaJIT/
+git checkout v2.1.ROLLING
 make && sudo make install
+sudo ln -sf "$(ls -1 /usr/local/bin/luajit-2.1* | sort | tail -n 1)" /usr/local/bin/luajit
 cd /tmp
 rm -rf LuaJIT
 


### PR DESCRIPTION
Moves to LuaJIT v2.1.ROLLING for the devcontainer

## What type of PR is this? (check all applicable)
- [X] 🤖 Build

## Description
2.1.ROLLING instead of main

## Manual test
<!-- Have you manually tested this code and confirmed it is working? -->
- [X] 👍 yes

## Manual test description
It builds the devcontainer correctly

## Added tests?
- [X] 🙅 no, because they aren't needed

## Added to documentation?
- [X] 🙅 no documentation needed
