### PR TITLE
Refactor channels to use direct buffering and improve perform_alt operations

### DIFF
--- a/fibers/channel.lua
+++ b/fibers/channel.lua
@@ -5,21 +5,7 @@
 -- @module fibers.channel
 
 local op = require 'fibers.op'
-
-local Fifo = {}
-Fifo.__index = Fifo
-local function new_fifo() return setmetatable({}, Fifo) end
-function Fifo:push(x) table.insert(self, x) end
-
-function Fifo:empty() return #self == 0 end
-
-function Fifo:peek()
-    assert(not self:empty()); return self[1]
-end
-
-function Fifo:pop()
-    assert(not self:empty()); return table.remove(self, 1)
-end
+local fifo = require 'fibers.utils.fifo'
 
 --- Channel class
 -- Represents a communication channel between fibers.
@@ -30,7 +16,7 @@ local Channel = {}
 -- @treturn Channel The created Channel.
 local function new()
     return setmetatable(
-        { getq = new_fifo(), putq = new_fifo() },
+        { getq = fifo.new(), putq = fifo.new() },
         { __index = Channel })
 end
 

--- a/fibers/channel.lua
+++ b/fibers/channel.lua
@@ -11,13 +11,14 @@ local fifo = require 'fibers.utils.fifo'
 -- Represents a communication channel between fibers.
 -- @type Channel
 local Channel = {}
+Channel.__index = Channel
 
 --- Create a new Channel.
 -- @treturn Channel The created Channel.
 local function new()
     return setmetatable(
         { getq = fifo.new(), putq = fifo.new() },
-        { __index = Channel })
+        Channel)
 end
 
 --- Create a put operation for the Channel.

--- a/fibers/op.lua
+++ b/fibers/op.lua
@@ -174,7 +174,6 @@ end
 -- @tparam function f The function.
 -- @treturn vararg The value returned by the operation or the function.
 function BaseOp:perform_alt(f)
-    fiber.yield() -- lessens race possibility
     local success, val = self.try_fn()
     if success then return self.wrap_fn(val) end
     return f()
@@ -184,7 +183,6 @@ end
 -- @tparam function f The function.
 -- @treturn vararg The value returned by the operation or the function.
 function ChoiceOp:perform_alt(f)
-    fiber.yield() -- lessens race possibility
     local ops = self.base_ops
     local base = math.random(#ops)
     for i = 1, #ops do

--- a/fibers/queue.lua
+++ b/fibers/queue.lua
@@ -1,64 +1,17 @@
 -- Use of this source code is governed by the Apache 2.0 license; see COPYING.
 
 --- fibers.queue module
--- Provides Concurrent ML style buffered channels for communication between fibers.
+-- Buffered channels for communication between fibers.
 -- @module fibers.queue
 
-local op = require 'fibers.op'
 local channel = require 'fibers.channel'
-local fiber = require 'fibers.fiber'
-
---- Queue class
--- Represents a queue for communication between fibers.
--- @type Queue
--- local Queue = {}
 
 --- Create a new Queue.
 -- @int[opt] bound The upper bound for the number of items in the queue.
 -- @treturn Queue The created Queue.
 local function new(bound)
     if bound then assert(bound >= 1) end
-    local ch_in, ch_out = channel.new(), channel.new()
-    local function service_queue()
-        local q = {}
-        while true do
-            if #q == 0 then
-                -- Empty.
-                table.insert(q, ch_in:get())
-            elseif bound and #q >= bound then
-                -- Full.
-                ch_out:put(q[1])
-                table.remove(q, 1)
-            else
-                local getop = ch_in:get_op()
-                local putop = ch_out:put_op(q[1])
-                local val = op.choice(getop, putop):perform()
-                if val == nil then
-                    -- Put operation succeeded.
-                    table.remove(q, 1)
-                else
-                    -- Get operation succeeded.
-                    table.insert(q, val)
-                end
-            end
-        end
-    end
-    fiber.spawn(service_queue)
-    local ret = {}
-    function ret:put_op(x)
-        assert(x ~= nil)
-        return ch_in:put_op(x)
-    end
-
-    function ret:get_op()
-        return ch_out:get_op()
-    end
-
-    function ret:put(x) self:put_op(x):perform() end
-
-    function ret:get() return self:get_op():perform() end
-
-    return ret
+    return channel.new(bound and bound or math.huge)
 end
 
 return {

--- a/fibers/utils/fifo.lua
+++ b/fibers/utils/fifo.lua
@@ -1,0 +1,56 @@
+--- fibers.fifo module
+-- A simple FIFO queue that can handle nil values.
+-- @module fibers.fifo
+
+local Fifo = {}
+Fifo.__index = Fifo
+
+--- Create a new FIFO queue.
+-- @treturn Fifo The created FIFO queue.
+local function new()
+    return setmetatable({
+        count = 0,    -- total items ever pushed
+        first = 1,    -- index of first item
+        items = {}    -- storage table
+    }, Fifo)
+end
+
+--- Push a value onto the queue.
+-- @param x The value to push (can be nil)
+function Fifo:push(x)
+    self.count = self.count + 1
+    self.items[self.count] = x
+end
+
+--- Check if the queue is empty.
+-- @treturn boolean True if empty
+function Fifo:empty()
+    return self.first > self.count
+end
+
+--- Peek at the first item without removing it.
+-- @return The first item
+function Fifo:peek()
+    assert(not self:empty(), "queue is empty")
+    return self.items[self.first]
+end
+
+--- Remove and return the first item.
+-- @return The first item
+function Fifo:pop()
+    assert(not self:empty(), "queue is empty")
+    local val = self.items[self.first]
+    self.items[self.first] = nil  -- allow GC
+    self.first = self.first + 1
+    return val
+end
+
+--- Return the length of the queue.
+-- @return The queue length
+function Fifo:length()
+    return self.count - self.first + 1
+end
+
+return {
+    new = new
+}

--- a/tests/test_channel.lua
+++ b/tests/test_channel.lua
@@ -27,26 +27,28 @@ end
 
 local function test_buffered()
     local chan, signal = channel.new(2), channel.new()
-    local results = {}
 
     fiber.spawn(function()
-        for i = 1, 3 do
+        for i = 1, 4 do
             chan:put(i)
-            table.insert(results, "put " .. i)
         end
         signal:put(true)
     end)
     fiber.spawn(function()
-        for i = 1, 3 do
+        for i = 1, 2 do
             assert(chan:get() == i)
-            table.insert(results, "get " .. i)
         end
-        signal:put(true)
     end)
 
     signal:get()
+    fiber.spawn(function()
+        chan:put(5)
+        signal:put(true)
+    end)
+    assert(chan:get() == 3)
     signal:get()
-    assert(results[3] == "get 1" and results[6] == "put 3", "buffered order")
+    assert(chan:get() == 4)
+    assert(chan:get() == 5)
     print("Bounded buffered passed")
 end
 
@@ -67,7 +69,7 @@ end
 local function test_concurrent()
     local chan, signal, results = channel.new(1), channel.new(), {}
     fiber.spawn(function()
-        for i = 1, 10 do chan:put(i) end
+        for i = 1, 11 do chan:put(i) end
         signal:put()
     end)
     fiber.spawn(function()

--- a/tests/test_queue.lua
+++ b/tests/test_queue.lua
@@ -14,16 +14,16 @@ local function record(x) table.insert(log, x) end
 
 fiber.spawn(function()
     local q = queue.new()
-    record('a');
-    q:put('b');
-    record('c');
-    q:put('d');
-    record('e');
+    record('a')
+    q:put('b')
+    record('c')
+    q:put('d')
+    record('e')
     record(q:get())
-    q:put('f');
-    record('g');
+    q:put('f')
+    record('g')
     record(q:get())
-    record('h');
+    record('h')
     record(q:get())
 end)
 
@@ -33,30 +33,8 @@ local function run(...)
     assert(equal(log, { ... }))
 end
 
--- 1. Main fiber runs, creating queue fiber.  It blocks trying to
--- hand off 'b' as the queue fiber hasn't run yet.
-run('a')
--- 2. Queue fiber runs, taking 'b', and thereby resuming the main
--- fiber (marking it runnable on the next turn).  Queue fiber blocks
--- trying to get or put.
-run()
--- 3. Main fiber runs, is able to put 'd' directly as the queue was
--- waiting on it, then blocks waiting for a 'get'.  Putting 'd'
--- resumed the queue fiber.
-run('c', 'e')
--- 4. Queue fiber takes 'd' and is also able to put 'a', resuming the
--- main fiber.
-run()
--- 5. Main fiber receives 'b', is able to put 'f' directly, blocks
--- getting from queue.
-run('b', 'g')
--- 6. Queue fiber resumed with 'f', puts 'd', then blocks.
-run()
--- 7. Main fiber resumed with 'd' and also succeeds getting 'f'.
-run('d', 'h', 'f')
--- 8. Queue resumes and blocks.
-run()
--- Nothing from here on out.
+-- With the new buffered channel implementation, the behavior is  direct:
+run('a', 'c', 'e', 'b', 'g', 'd', 'h', 'f')
 for _ = 1, 20 do run() end
 
 print('test: ok')


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [X] 🐛 Bug Fix
- [X] 🔥 Performance Improvements

## Description

**Changes:** 
1. New fifo that allows for `nil` sends over channels
2. Implemented unified un/buffered `channel.lua`  
3. Updated `queue.lua` to use the new buffered channel implementation rather than an intermediate fiber
4. Removed `fiber.yield()` from `perform_alt` methods since we should only be using never-yielding `try()` operations  
5. Revised tests to verify:  
   - Correct buffered channel behaviour  
   - Backward compatibility  

**Benefits:**  
- Eliminates race conditions in perform_alt operations  
- Reduces context switches by removing intermediate fibers  
- Maintains identical API while improving performance  
- More closely matches Go's channel semantics (`nil` sends and unified channel implementation) 

## Related Issues, Tickets & Documents
should fix https://github.com/jangala-dev/devicecode-lua/issues/46

## Manual test
- [X] 🙅 no

## Added tests?
- [X] 👍 yes

- All existing tests pass with modified expectations  
- Added new tests for concurrent buffered operations  

## Added to documentation?
- [X] 🙅 no documentation needed