### PR TITLE
Propagate kill

### DIFF
--- a/fibers/exec.lua
+++ b/fibers/exec.lua
@@ -59,7 +59,8 @@ end
 -- Re-emits the specified signals to the child process (or its process group,
 -- if setpgid(true) is used). This mirrors the behaviour of Go’s exec.Cmd and
 -- allows child processes to receive termination signals like SIGINT or SIGTERM.
-function Cmd:forward_signals(signals)
+function Cmd:forward_signals(...)
+    local signals = { ... }
     for _, sig in ipairs(signals) do
         sc.signal(sig, function()
             if self.process and self.process.pid then

--- a/fibers/exec.lua
+++ b/fibers/exec.lua
@@ -23,7 +23,7 @@ Cmd.__index = Cmd -- set metatable
 local function command(name, ...)
     local self = setmetatable({}, Cmd)
     self.path = name
-    self.args = {...}
+    self.args = { ... }
     self.process = {}
     self.pipes = {
         child = {},
@@ -50,6 +50,12 @@ function Cmd:setpgid(status)
     return self
 end
 
+--- Sets the signal to send to the child process on parent death.
+--- @param sig integer The signal to send.
+function Cmd:setprdeathsig(sig)
+    self._prdeathsig = sig
+    return self
+end
 -- Re-emits the specified signals to the child process (or its process group,
 -- if setpgid(true) is used). This mirrors the behaviour of Go’s exec.Cmd and
 -- allows child processes to receive termination signals like SIGINT or SIGTERM.
@@ -63,8 +69,8 @@ function Cmd:forward_signals(signals)
         end)
     end
 end
-function Cmd:_output_collector(pipes)
 
+function Cmd:_output_collector(pipes)
     local function close_pipes()
         for i = #pipes, 1, -1 do
             pipes[i]:close()
@@ -143,6 +149,7 @@ function Cmd:start()
 
     local pid = assert(sc.fork())
     if pid == 0 then -- child
+        if self._prdeathsig then sc.prctl(sc.PR_SET_PDEATHSIG, self._prdeathsig) end
         if self._setpgid then assert(sc.setpid('p', 0, 0) == 0) end
 
         -- pipework
@@ -190,7 +197,7 @@ function Cmd:kill()
 
     local target = self._setpgid and -self.process.pid or self.process.pid
     local res, err, errno = sc.kill(target, sc.SIGKILL)
-    assert(res==0 or errno==sc.ESRCH, err)
+    assert(res == 0 or errno == sc.ESRCH, err)
 end
 
 function Cmd:_pipe_creator(stdio)
@@ -199,6 +206,7 @@ function Cmd:_pipe_creator(stdio)
     self.pipes.child[stdio] = (stdio == 'stdin') and rd or wr
     return file.fdopen(self.pipes.parent[stdio])
 end
+
 --- Creates a pipe for stdout. Call `:close()` when finished.
 -- @return The stdout pipe or an error.
 function Cmd:stdout_pipe() return self:_pipe_creator('stdout') end

--- a/fibers/exec.lua
+++ b/fibers/exec.lua
@@ -50,6 +50,19 @@ function Cmd:setpgid(status)
     return self
 end
 
+-- Re-emits the specified signals to the child process (or its process group,
+-- if setpgid(true) is used). This mirrors the behaviour of Go’s exec.Cmd and
+-- allows child processes to receive termination signals like SIGINT or SIGTERM.
+function Cmd:forward_signals(signals)
+    for _, sig in ipairs(signals) do
+        sc.signal(sig, function()
+            if self.process and self.process.pid then
+                local target = self._setpgid and -self.process.pid or self.process.pid
+                sc.kill(target, sig)
+            end
+        end)
+    end
+end
 function Cmd:_output_collector(pipes)
 
     local function close_pipes()

--- a/fibers/utils/syscall.lua
+++ b/fibers/utils/syscall.lua
@@ -105,6 +105,7 @@ M.SOMAXCONN = p_socket.SOMAXCONN
 
 M.WNOHANG = p_wait.WNOHANG
 
+M.PR_SET_PDEATHSIG = 1
 -------------------------------------------------------------------------------
 -- Luafied stdlib syscalls
 
@@ -229,6 +230,8 @@ ffi.cdef[[
     int fcntl(int fd, int cmd, ...);
     int close(int fd);
     char *strerror(int errnum);
+
+    int prctl(int option, unsigned long arg2, unsigned long arg3, unsigned long arg4, unsigned long arg5);
 ]]
 
 M.EPOLLIN = 0x00000001
@@ -342,6 +345,14 @@ function M.epoll_close(epfd)
     return wrap_error(ffi.C.close(epfd))
 end
 
+function M.prctl(option, arg2, arg3, arg4, arg5)
+    arg2 = arg2 or 0
+    arg3 = arg3 or 0
+    arg4 = arg4 or 0
+    arg5 = arg5 or 0
+
+    return wrap_error(ffi.C.prctl(option, arg2, arg3, arg4, arg5))
+end
 
 -------------------------------------------------------------------------------
 -- FFI C structure functions (for efficiency)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] 🍕 Feature
- [] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description
Adds option to forward signals to child processes using `cmd:forward_signals(signals)`, useful if the child is in a separate process group. Can now set parent death signal using `cmd:setprdeathig(signal)`, which fixes cases where a parent may crash leaving an orphaned process to never close.

## Related Issues, Tickets & Documents
https://github.com/jangala-dev/devicecode-lua/issues/45

## Manual test
<!-- Have you manually tested this code and confirmed it is working? -->
- [x] 👍 yes
- [ ] 🙅 no

## Manual test description
Make a lua script to make an exec command of `sleep infinity`,  set parent death sig to `sc.SIGKILL`, run the command and then do a crashing operation, for example a nil index (`print(nil_obj.item)`). After the script crashes check for a sleep command with `ps`, sleep should not be seen.

## Added tests?
- [x] 👍 yes (parent death sig only, not forward signals)
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?
- [ ] 📜 README.md
- [x] Commented
- [ ] 🙅 no documentation needed

