### PR TITLE
add bracket, reworked op and top-level perform

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,17 @@ local function fibonacci(c, quit)
     local x, y = 0, 1
     local done = false
     repeat
-        op.choice(
-            c:put_op(x):wrap(function(value)
-                x, y = y, x+y
-            end),
-            quit:get_op():wrap(function(value)
-                print("quit")
-                done = true
-            end)
-        ):perform()
+        perform(
+            choice(
+                c:put_op(x):wrap(function(value)
+                    x, y = y, x+y
+                end),
+                quit:get_op():wrap(function(value)
+                    print("quit")
+                    done = true
+                end)
+            )
+        )
     until done
 end
 
@@ -35,7 +37,7 @@ end)
 fiber.main()
 ```
 
-Ported from the Snabb Project's [`fibers`](https://github.com/snabbco/snabb/tree/master/src/lib/fibers) and [`streams`](https://github.com/snabbco/snabb/tree/master/src/lib/stream) libraries, written by 
+Ported from the Snabb Project's [`fibers`](https://github.com/snabbco/snabb/tree/master/src/lib/fibers) and [`streams`](https://github.com/snabbco/snabb/tree/master/src/lib/stream) libraries, written by
 Andy Wingo as an implementation of Reppy et al's Concurrent ML(CML), and a fibers-based reimplementation of Lua's streams enabling smooth non-blocking access to files and sockets.
 
 Inspired by Andy's [blog post](https://wingolog.org/archives/2018/05/16/lightweight-concurrency-in-lua) introducing fibers on Lua
@@ -55,7 +57,7 @@ with the following points to bear in mind:
 ## Installation
 
 This is a pure Lua (with FFI) module with the following dependencies:
-  - lua-posix (for micro/nano timing and sleeping options, for forking and 
+  - lua-posix (for micro/nano timing and sleeping options, for forking and
   other syscall operations)
   - libffi and lua-cffi (if not using LuaJIT)
   - lua-bit32 (if not using LuaJIT)
@@ -76,7 +78,7 @@ These dependencies will be installed in a VScode devcontainer automatically. To 
 
 ### Installation with LuaJIT on OpenWRT
 
-This is the simplest set up for running on OpenWRT.  
+This is the simplest set up for running on OpenWRT.
 
 `opkg update; opkg install luajit; opkg install luaposix`
 
@@ -111,15 +113,15 @@ This library implements a simple version of Concurrent ML(CML), and provides pri
 
 ## Progress
 
-All of the Snabb 'fibers' modules the following have so far been ported and 
-tested. All of Snabb's 'stream' module has also been ported, which can do 
-non-blocking reads and writes from file descriptors using familiar `line` 
-and `all` approaches. 
+All of the Snabb 'fibers' modules the following have so far been ported and
+tested. All of Snabb's 'stream' module has also been ported, which can do
+non-blocking reads and writes from file descriptors using familiar `line`
+and `all` approaches.
 
 We use the `cffi` module to port Wingo's `luajit` C ffi based
 buffers implementation in a way that will work across multiple architectures, as
 Lua versions of these buffers would be inefficient and lead to allocation and
-garbage collection without a substantial investment of time. 
+garbage collection without a substantial investment of time.
 
 ## Structured concurrency
 

--- a/examples/1-basic-usage/4-choices.lua
+++ b/examples/1-basic-usage/4-choices.lua
@@ -12,11 +12,13 @@ local fiber = require 'fibers.fiber'
 local channel = require 'fibers.channel'
 local op = require 'fibers.op'
 
+local perform, choice = op.perform, op.choice
+
 local function fibonacci(c, quit)
     local x, y = 0, 1
     local done = false
     repeat
-        op.choice(
+        local task = choice(
             c:put_op(x):wrap(function()
                 x, y = y, x+y
             end),
@@ -24,7 +26,8 @@ local function fibonacci(c, quit)
                 print("quit")
                 done = true
             end)
-        ):perform()
+        )
+        perform(task)
     until done
 end
 

--- a/examples/1-basic-usage/5-choices-alt.lua
+++ b/examples/1-basic-usage/5-choices-alt.lua
@@ -11,6 +11,8 @@ local channel = require 'fibers.channel'
 local sleep = require 'fibers.sleep'
 local op = require 'fibers.op'
 
+local perform, choice = op.perform, op.choice
+
 -- time.After() is a Go library function
 local function after(t)
     local chan = channel.new()
@@ -38,7 +40,7 @@ fiber.spawn(function()
     local boom = after(0.5)
     local done = false
     repeat
-        op.choice(
+        local task = choice(
             ticker:get_op():wrap(function()
                 print("tick.")
             end),
@@ -46,10 +48,11 @@ fiber.spawn(function()
                 print("BOOM!")
                 done = true
             end)
-        ):perform_alt(function()
+        ):or_else(function()
             print("    .")
             sleep.sleep(0.05)
         end)
+        perform(task)
     until done
 
     fiber.stop()

--- a/examples/1-basic-usage/context-examples.lua
+++ b/examples/1-basic-usage/context-examples.lua
@@ -5,6 +5,8 @@ local context = require 'fibers.context'
 local sleep = require 'fibers.sleep'
 local op = require 'fibers.op'
 
+local perform = op.perform
+
 -- Simulated work function
 local function do_work(task_name, duration)
     print(task_name .. " started")
@@ -20,8 +22,7 @@ local function sub_task_1(ctx)
         cancel("work_completed") -- Cancel the context (optional, as it will timeout)
     end)
 
-    local done_op = deadline_ctx:done_op()
-    op.choice(done_op):perform() -- Wait for the context to be done
+    perform(deadline_ctx:done_op()) -- Wait for the context to be done
     print("Sub-Task 1 status: " .. (deadline_ctx:err() or "completed"))
 end
 
@@ -33,8 +34,7 @@ local function sub_task_2(ctx)
         cancel("work_completed") -- Cancel the context when work is done
     end)
 
-    local done_op = cancel_ctx:done_op()
-    op.choice(done_op):perform() -- Wait for the context to be done
+    perform(cancel_ctx:done_op()) -- Wait for the context to be done
     print("Sub-Task 2 status: " .. (cancel_ctx:err() or "completed"))
 end
 

--- a/fibers/alarm.lua
+++ b/fibers/alarm.lua
@@ -7,6 +7,8 @@ local fiber = require 'fibers.fiber'
 local timer = require 'fibers.timer'
 local sc = require 'fibers.utils.syscall'
 
+local perform = op.perform
+
 local function days_in_year(y)
     return y % 4 == 0 and (y % 100 ~= 0 or y % 400 == 0) and 366 or 365
 end
@@ -240,7 +242,7 @@ end
 -- Wrapper for `absolute_op` that immediately performs the operation.
 -- @param t The absolute time (epoch) for the alarm.
 local function wait_absolute(t)
-    return wait_absolute_op(t):perform()
+    return perform(wait_absolute_op(t))
 end
 
 --- Creates an operation for a next (relative) alarm.
@@ -260,7 +262,7 @@ end
 -- @return An error if the time table is invalid.
 local function wait_next(t)
     local _, err = validate_next_table(t)
-    return err or assert(installed_alarm_handler):wait_next_op(t):perform()
+    return err or perform(assert(installed_alarm_handler):wait_next_op(t))
 end
 
 -- Public API

--- a/fibers/channel.lua
+++ b/fibers/channel.lua
@@ -7,6 +7,8 @@
 local op = require 'fibers.op'
 local fifo = require 'fibers.utils.fifo'
 
+local perform = op.perform
+
 --- Channel class
 -- Represents a communication channel between fibers.
 -- @type Channel
@@ -115,7 +117,7 @@ end
 -- continue.  Otherwise, block until a receiver becomes available.
 -- @tparam any message The message to put into the Channel.
 function Channel:put(message)
-    self:put_op(message):perform()
+    return perform(self:put_op(message))
 end
 
 --- Get a message from the Channel.
@@ -125,7 +127,7 @@ end
 -- available.
 -- @treturn any The message retrieved from the Channel.
 function Channel:get()
-    return self:get_op():perform()
+    return perform(self:get_op())
 end
 
 --- @export

--- a/fibers/cond.lua
+++ b/fibers/cond.lua
@@ -6,6 +6,8 @@
 
 local op = require 'fibers.op'
 
+local perform = op.perform
+
 local Cond = {}
 Cond.__index = Cond
 
@@ -24,7 +26,7 @@ end
 
 --- Put the fiber into a wait state on the condition variable.
 function Cond:wait()
-    return self:wait_op():perform()
+    return perform(self:wait_op())
 end
 
 --- Wake up all fibers that are waiting on this condition variable.

--- a/fibers/op.lua
+++ b/fibers/op.lua
@@ -1,7 +1,34 @@
 --- fibers.op module
 -- Provides Concurrent ML style operations for managing concurrency.
 -- Events are CML-style: primitive leaves, choices, guards, with_nack,
--- and wraps. Synchronization compiles an event tree into primitive leaves.
+-- wraps, and an extra abort combinator (on_abort).
+--
+-- Core event AST kinds:
+--   prim      : primitive leaf { try_fn, block_fn, wrap_fn }
+--   choice    : non-empty list of events
+--   guard     : delayed event builder (run once per sync)
+--   with_nack : CML-style nack combinator
+--   wrap      : post-commit mapper (composed at compile time)
+--   abort     : attach abort handler to an event (run if this arm loses)
+--
+-- Semantics sketch
+-- ----------------
+-- We keep CML-style semantics for with_nack:
+--   - with_nack g gets a nack event that becomes enabled iff the
+--     *entire* resulting event loses in an enclosing choice.
+--   - nested with_nack behaves correctly: outer nacks only fire when
+--     the outer event loses, not when internal subchoices resolve.
+--
+-- `on_abort(ev, f)` is implemented in terms of the same "nack" machinery:
+--   - each abort scope behaves like a nack-cond whose signal() runs f().
+--   - after a choice commits, we figure out which conds are associated
+--     exclusively with losing arms and signal those once.
+--
+-- We also provide:
+--   - bracket(acquire, release, use): RAII-style resource protocol.
+--   - else_next_turn(ev, fallback_ev): biased choice; prefer ev, but
+--     if it doesn't commit "by next turn", abort it cleanly and run
+--     fallback_ev (in a separate sync).
 
 local fiber  = require 'fibers.fiber'
 
@@ -75,6 +102,7 @@ end
 -- kind = 'guard'     : { builder = function() -> Event }
 -- kind = 'with_nack' : { builder = function(nack_ev) -> Event }
 -- kind = 'wrap'      : { inner = Event, wrap_fn = f }
+-- kind = 'abort'     : { inner = Event, abort_fn = f }
 ----------------------------------------------------------------------
 
 local Event = {}
@@ -116,13 +144,50 @@ local function guard(g)
     return setmetatable({ kind = 'guard', builder = g }, Event)
 end
 
--- with_nack g: delayed event; g(nack_ev) evaluated once per synchronization.
--- nack_ev is an Event that becomes ready iff this with_nack is *not* chosen.
+-- CML-style with_nack: builder gets a nack event that becomes ready
+-- iff this event participates in a choice and *loses*.
 local function with_nack(g)
     return setmetatable({ kind = 'with_nack', builder = g }, Event)
 end
 
--- Wrap event with a post-processing function f.
+-- next_turn_op: primitive event that is never ready in the fast path;
+-- if forced to block, it completes itself on the *next scheduler turn*.
+local function next_turn_op()
+    local function try()
+        return false
+    end
+
+    local function block(suspension, wrap_fn)
+        local task = suspension:complete_task(wrap_fn)
+        suspension.sched:schedule(task)
+    end
+
+    return new_base_op(nil, try, block)
+end
+
+local function always(value)
+    return new_base_op(nil,
+        function() return true, value end,
+        function() error("always: block_fn should never run") end)
+end
+
+local function never()
+    -- An event that never becomes ready
+    return new_base_op(nil,
+        function() return false end,
+        function() end)
+end
+
+function Event:or_else(fallback_thunk)
+    return choice(
+        self,
+        next_turn_op():wrap(function()
+            return fallback_thunk()
+        end)
+    )
+end
+
+-- Wrap event with a post-processing function f (commit phase).
 -- This is another node in the tree; composed at compile time.
 function Event:wrap(f)
     return setmetatable(
@@ -131,17 +196,29 @@ function Event:wrap(f)
     )
 end
 
+-- Attach an abort handler to this event.
+-- f() is run iff this event participates in a choice and *does not win*.
+function Event:on_abort(f)
+    assert(type(f) == 'function', "on_abort expects a function")
+    return setmetatable(
+        { kind = 'abort', inner = self, abort_fn = f },
+        Event
+    )
+end
+
 ----------------------------------------------------------------------
 -- Simple one-shot condition primitive (used for with_nack; also exported)
 ----------------------------------------------------------------------
 
-local function new_cond()
+local function new_cond(opts)
     local state = {
         triggered = false,
-        waiters   = {}, -- array of CompleteTask
+        waiters   = {},        -- optional
+        abort_fn  = opts and opts.abort_fn or nil,
     }
 
     local function wait_op()
+        assert(not state.abort_fn, "abort-only cond has no wait_op")
         local function try()
             return state.triggered
         end
@@ -149,7 +226,8 @@ local function new_cond()
             if state.triggered then
                 suspension:complete(wrap_fn)
             else
-                state.waiters[#state.waiters + 1] = suspension:complete_task(wrap_fn)
+                state.waiters[#state.waiters + 1] =
+                    suspension:complete_task(wrap_fn)
             end
         end
         return new_base_op(nil, try, block)
@@ -158,17 +236,25 @@ local function new_cond()
     local function signal()
         if state.triggered then return end
         state.triggered = true
+        -- wake waiters, if any
         for i = 1, #state.waiters do
             local task = state.waiters[i]
             state.waiters[i] = nil
-            if task and task.suspension and task.suspension:waiting() then
+            if task
+                and task.suspension
+                and task.suspension:waiting()
+            then
                 task.suspension.sched:schedule(task)
             end
+        end
+        -- fire abort handler, if any
+        if state.abort_fn then
+            pcall(state.abort_fn)
         end
     end
 
     return {
-        wait_op = wait_op,
+        wait_op = state.abort_fn and nil or wait_op,
         signal  = signal,
     }
 end
@@ -181,8 +267,13 @@ end
 --     try_fn,
 --     block_fn,
 --     wrap,          -- final wrap function for this leaf
---     nacks = {...}, -- list of all active with_nack conds on this path
+--     nacks = {...}, -- list of all active nack/abort conds on this path
 --   }
+--
+-- Semantics:
+--   - Each with_nack or abort node adds a cond to the nacks list.
+--   - After a winner leaf is chosen, we find which conds appear only
+--     on losing paths and signal those once (CML-style nack).
 ----------------------------------------------------------------------
 
 local function compile_event(ev, outer_wrap, out, nacks)
@@ -203,12 +294,11 @@ local function compile_event(ev, outer_wrap, out, nacks)
 
     elseif kind == 'with_nack' then
         local cond    = new_cond()
-        local nack_ev = cond.wait_op() -- Event
+        local nack_ev = cond.wait_op()
         local inner   = ev.builder(nack_ev)
-        -- Extend the current nack list for this subtree
-        local child_nacks             = { unpack(nacks) }
-        child_nacks[#child_nacks + 1] = cond
 
+        local child_nacks = { unpack(nacks) }
+        child_nacks[#child_nacks + 1] = cond
         compile_event(inner, outer_wrap, out, child_nacks)
 
     elseif kind == 'wrap' then
@@ -218,7 +308,14 @@ local function compile_event(ev, outer_wrap, out, nacks)
         end
         compile_event(ev.inner, new_outer, out, nacks)
 
+    elseif kind == 'abort' then
+        local cond        = new_cond{ abort_fn = ev.abort_fn }
+        local child_nacks = { unpack(nacks) }
+        child_nacks[#child_nacks + 1] = cond
+        compile_event(ev.inner, outer_wrap, out, child_nacks)
+
     else -- 'prim'
+        -- Each leaf gets a unique final_wrap closure so identity comparison in
         local final_wrap = function(...)
             return outer_wrap(ev.wrap_fn(...))
         end
@@ -237,29 +334,36 @@ end
 -- Nack triggering and non-blocking attempt
 ----------------------------------------------------------------------
 
--- Signal all with_nack conds that belong exclusively to losing arms.
+-- Signal all conds that belong exclusively to losing arms.
+-- This is the original CML-style logic:
+--   - Build set of nacks on the winner path.
+--   - For each loser leaf, signal any nacks not in the winner set.
+--   - Each cond object is responsible for idempotence.
 local function trigger_nacks(ops, winner_index)
-    -- Build a set of conds to *skip* (all on the winner path).
-    local winner = {}
-    if winner_index then
-        local wnacks = ops[winner_index].nacks
-        if wnacks then
-            for i = 1, #wnacks do
-                winner[wnacks[i]] = true
-            end
+    assert(winner_index, "trigger_nacks: no winner_index (internal error)")
+
+    local winner_set = {}
+    local wnacks     = ops[winner_index].nacks
+    if wnacks then
+        for i = 1, #wnacks do
+            winner_set[wnacks[i]] = true
         end
     end
 
-    -- Signal each losing cond once.
     local signaled = {}
     for i = 1, #ops do
-        local nacks = ops[i].nacks
-        if nacks then
-            for j = 1, #nacks do
-                local cond = nacks[j]
-                if cond and not winner[cond] and not signaled[cond] then
-                    signaled[cond] = true
-                    cond.signal()
+        if i ~= winner_index then
+            local nacks = ops[i].nacks
+            if nacks then
+                for j = #nacks, 1, -1 do
+                    local cond = nacks[j]
+                    if cond
+                        and not winner_set[cond]
+                        and not signaled[cond]
+                    then
+                        signaled[cond] = true
+                        cond.signal()
+                    end
                 end
             end
         end
@@ -300,54 +404,71 @@ local function block_choice_op(sched, fib, ops)
 end
 
 ----------------------------------------------------------------------
--- Event methods: perform, poll, perform_alt
+-- Event methods: perform, perform_alt
 ----------------------------------------------------------------------
 
 -- Perform this event (primitive or composite), possibly blocking.
-function Event:perform()
-    local ops = compile_event(self)
+local function perform(ev)
+    local leaves = compile_event(ev)
 
-    -- Fast path: non-blocking attempt.
-    local idx, retval = try_ready(ops)
+    -- Fast path
+    local idx, retval = try_ready(leaves)
     if idx then
-        trigger_nacks(ops, idx)
-        return apply_wrap(ops[idx].wrap, retval)
+        trigger_nacks(leaves, idx)
+        return apply_wrap(leaves[idx].wrap, retval)
     end
 
-    -- Slow path: block on all compiled leaves.
-    local suspended = pack(fiber.suspend(block_choice_op, ops))
+    -- Slow path
+    local suspended = pack(fiber.suspend(block_choice_op, leaves))
     local wrap      = suspended[1]
 
-    -- Find the winning leaf by matching its wrap function.
     local winner_index
-    for i, op in ipairs(ops) do
-        if op.wrap == wrap then
+    for i, leaf in ipairs(leaves) do
+        if leaf.wrap == wrap then
             winner_index = i
             break
         end
     end
-    trigger_nacks(ops, winner_index)
 
+    trigger_nacks(leaves, winner_index)
     return wrap(unpack(suspended, 2, suspended.n))
 end
 
--- poll: non-blocking synchronization attempt.
--- Returns (true, ...results) if some arm commits, or (false) otherwise.
-function Event:poll()
-    local ops = compile_event(self)
-    local idx, retval = try_ready(ops)
-    if not idx then return false end
-    trigger_nacks(ops, idx)
-    return true, apply_wrap(ops[idx].wrap, retval)
-end
+----------------------------------------------------------------------
+-- bracket : (acquire, release, use) -> 'a event
+--
+-- acquire()          : -> resource
+-- release(resource, aborted:boolean)
+-- use(resource)      : -> Event (the main action)
+--
+-- Semantics:
+--   * acquire is run once, at sync time (inside a guard).
+--   * if the resulting event `ev` WINS:
+--       - its result is returned
+--       - release(res, false) is called (best-effort, pcall)
+--   * if the resulting event PARTICIPATES in a choice but LOSES:
+--       - release(res, true) is called (via on_abort / nack machinery)
+--
+-- This is *purely an Event combinator*; no new fiber is spawned.
+----------------------------------------------------------------------
 
--- perform_alt: non-blocking; if no arm ready, call f().
-function Event:perform_alt(f)
-    local res = pack(self:poll())
-    if res[1] then
-        return unpack(res, 2, res.n)
+local function bracket(acquire, release, use)
+  return guard(function()
+    local res = acquire()
+    local ok, ev = pcall(use, res)
+    if not ok then
+      pcall(release, res, true)     -- ensure cleanup on builder failure
+      error(ev)
     end
-    return f()
+    return ev
+      :wrap(function(...)
+        pcall(release, res, false)
+        return ...
+      end)
+      :on_abort(function()
+        pcall(release, res, true)
+      end)
+  end)
 end
 
 ----------------------------------------------------------------------
@@ -355,9 +476,14 @@ end
 ----------------------------------------------------------------------
 
 return {
-    new_base_op = new_base_op, -- primitive event constructor
-    choice      = choice,
-    guard       = guard,
-    with_nack   = with_nack,
-    new_cond    = new_cond,
+    perform        = perform,
+    new_base_op    = new_base_op, -- primitive event constructor
+    choice         = choice,
+    guard          = guard,
+    with_nack      = with_nack,
+    new_cond       = new_cond,
+    bracket        = bracket,
+    always         = always,
+    never          = never,
+    -- Event instances have methods: wrap, on_abort.
 }

--- a/fibers/pollio.lua
+++ b/fibers/pollio.lua
@@ -8,6 +8,8 @@ local epoll = require 'fibers.epoll'
 local sc = require 'fibers.utils.syscall'
 local bit = rawget(_G, "bit") or require 'bit32'
 
+local perform = op.perform
+
 local PollIOHandler = {}
 PollIOHandler.__index = PollIOHandler
 
@@ -172,13 +174,13 @@ local function fd_readable_op(fd)
     return assert(installed_poll_handler):fd_readable_op(fd)
 end
 local function fd_readable(fd)
-    return fd_readable_op(fd):perform()
+    return perform(fd_readable_op(fd))
 end
 local function fd_writable_op(fd)
     return assert(installed_poll_handler):fd_writable_op(fd)
 end
 local function fd_writable(fd)
-    return fd_writable_op(fd):perform()
+    return perform(fd_writable_op(fd))
 end
 local function stream_readable_op(stream)
     return assert(installed_poll_handler):stream_readable_op(stream)

--- a/fibers/sleep.lua
+++ b/fibers/sleep.lua
@@ -7,6 +7,8 @@
 local op = require 'fibers.op'
 local fiber = require 'fibers.fiber'
 
+local perform = op.perform
+
 --- Timeout class.
 -- Represents a timeout for a fiber.
 -- @type Timeout
@@ -29,7 +31,7 @@ end
 --- Put the current fiber to sleep until time t.
 -- @tparam number t The time to sleep until.
 local function sleep_until(t)
-    return sleep_until_op(t):perform()
+    return perform(sleep_until_op(t))
 end
 
 --- Create a new operation that puts the current fiber to sleep for a duration dt.
@@ -46,7 +48,7 @@ end
 --- Put the current fiber to sleep for a duration dt.
 -- @tparam number dt The duration to sleep.
 local function sleep(dt)
-    return sleep_op(dt):perform()
+    return perform(sleep_op(dt))
 end
 
 return {

--- a/fibers/stream.lua
+++ b/fibers/stream.lua
@@ -9,6 +9,8 @@ local op                  = require 'fibers.op'
 local fixed_buffer        = require 'fibers.utils.fixed_buffer'
 local buffer              = require 'string.buffer'
 
+local perform = op.perform
+
 local unpack = table.unpack or unpack  -- luacheck: ignore -- Compatibility fallback
 
 local Stream = {}
@@ -148,7 +150,7 @@ end
 -- @return number of bytes written
 -- @return error encountered during the write
 function Stream:write_chars(str)
-    return self:write_chars_op(str):perform()
+    return perform(self:write_chars_op(str))
 end
 
 local function core_read_op(stream, buf, min, max, terminator)
@@ -244,7 +246,7 @@ end
 -- @return string containing the characters read
 -- @return error during read, if any
 function Stream:read_chars(count)
-    return self:read_chars_op(count):perform()
+    return perform(self:read_chars_op(count))
 end
 
 --- Operation to read up to a specified number of characters from the stream.
@@ -263,7 +265,7 @@ end
 -- @return string containing the characters read
 -- @return error during read, if any
 function Stream:read_some_chars(count)
-    return self:read_some_chars_op(count):perform()
+    return perform(self:read_some_chars_op(count))
 end
 
 --- Operation to read all characters from the stream.
@@ -279,7 +281,7 @@ end
 -- @return string containing all characters read
 -- @return error during read, if any
 function Stream:read_all_chars()
-    return self:read_all_chars_op():perform()
+    return perform(self:read_all_chars_op())
 end
 
 --- Operation to read a single character from the stream.
@@ -295,7 +297,7 @@ end
 -- @return the character read, or nil if at end of file
 -- @return error during read, if any
 function Stream:read_char()
-    return self:read_char_op():perform()
+    return perform(self:read_char_op())
 end
 
 --- Operation to read a line from the stream.
@@ -316,7 +318,7 @@ end
 -- @return the line read, or nil if at end of file
 -- @return error during read, if any
 function Stream:read_line(style)
-    return self:read_line_op(style):perform()
+    return perform(self:read_line_op(style))
 end
 
 function Stream:flush_input()
@@ -335,7 +337,7 @@ end
 
 --- Flush the output buffer, writing all buffered data to the underlying IO.
 function Stream:flush_output()
-    return self:flush_output_op():perform()
+    return perform(self:flush_output_op())
 end
 
 Stream.flush = Stream.flush_output
@@ -397,7 +399,7 @@ end
 -- @return the data read from the stream according to the specified format, or nil on end of file
 -- @return error during read, if any
 function Stream:read(...)
-    return self:read_op(...):perform()
+    return perform(self:read_op(...))
 end
 
 --- Get or set the file position.
@@ -492,7 +494,7 @@ end
 -- @param ... data to write (strings or numbers)
 -- @return true on success, or nil plus an error message on failure
 function Stream:write(...)
-    return self:write_op(...):perform()
+    return perform(self:write_op(...))
 end
 
 -- The result may be nil.

--- a/fibers/stream/file.lua
+++ b/fibers/stream/file.lua
@@ -7,8 +7,11 @@
 package.path = "../../?.lua;../?.lua;" .. package.path
 
 local stream = require 'fibers.stream'
+local op = require 'fibers.op'
 local pollio = require 'fibers.pollio'
 local sc = require 'fibers.utils.syscall'
+
+local perform = op.perform
 
 local pio_handler = pollio.install_poll_io_handler()
 
@@ -88,11 +91,11 @@ end
 
 function File:wait_for_readable_op() return pollio.fd_readable_op(self.fd) end
 
-function File:wait_for_readable() self:wait_for_readable_op():perform() end
+function File:wait_for_readable() perform(self:wait_for_readable_op()) end
 
 function File:wait_for_writable_op() return pollio.fd_writable_op(self.fd) end
 
-function File:wait_for_writable() self:wait_for_writable_op():perform() end
+function File:wait_for_writable() perform(self:wait_for_writable_op()) end
 
 function File:task_on_readable(t) if self.fd then pio_handler:task_on_readable(self.fd, t) end end
 

--- a/fibers/waitgroup.lua
+++ b/fibers/waitgroup.lua
@@ -1,6 +1,8 @@
 -- waitgroup.lua
 local op = require 'fibers.op'
 
+local perform = op.perform
+
 local Waitgroup = {}
 Waitgroup.__index = Waitgroup
 
@@ -47,7 +49,7 @@ function Waitgroup:wait_op()
 end
 
 function Waitgroup:wait()
-    self:wait_op():perform()
+    return perform(self:wait_op())
 end
 
 return {

--- a/tests/test_context.lua
+++ b/tests/test_context.lua
@@ -6,7 +6,10 @@ package.path = "../?.lua;" .. package.path
 
 local context = require 'fibers.context'
 local fiber = require 'fibers.fiber'
+local op = require 'fibers.op'
 local sleep = require 'fibers.sleep'
+
+local perform = op.perform
 
 -- Test Background Context
 local function test_background()
@@ -23,7 +26,7 @@ local function test_with_cancel()
 
     local is_cancelled = false
     fiber.spawn(function()
-        child_ctx:done_op():perform()
+        perform(child_ctx:done_op())
         is_cancelled = true
     end)
 
@@ -54,7 +57,7 @@ local function test_with_timeout()
 
     local is_cancelled = false
     fiber.spawn(function()
-        ctx:done_op():perform()
+        perform(ctx:done_op())
         is_cancelled = true
     end)
 

--- a/tests/test_stream-file.lua
+++ b/tests/test_stream-file.lua
@@ -14,6 +14,8 @@ local compat    = require 'fibers.stream.compat'
 
 compat.install()
 
+local perform, choice = op.perform, op.choice
+
 local function test()
     local rd, wr = file.pipe()
     local message = "hello, world\n"
@@ -77,10 +79,11 @@ local function test_read_op()
         wg:done()
     end)
 
-    local chars, err = op.choice(
+    local task = choice(
         rd:read_all_chars_op(),
         sleep.sleep_op(0.01):wrap(function () return nil, 'timeout' end)
-    ):perform()
+    )
+    local chars, err = perform(task)
 
     assert(not chars and err == 'timeout')
 
@@ -118,10 +121,11 @@ local function test_write_op()
         wg:done()
     end)
 
-    local written, err = op.choice(
+    local task = choice(
         wr:write_chars_op(msg..msg2),
         sleep.sleep_op(0.01):wrap(function () return nil, 'timeout' end)
-    ):perform()
+    )
+    local written, err = perform(task)
 
     assert(not written and err=='timeout')
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

* [x] 🍕 Feature
* [x] 📝 Documentation Update
* [x] 🧑‍💻 Code Refactor
* [x] ✅ Test

## Description

Pushes `fibers.op` towards a first-class CML event API and rewires the library, examples, and tests around an explicit `perform` entry point.

Main changes:

* **Core op API**

  * Introduces `op.perform(ev)` as the single synchronization primitive, instead of calling `:perform()` on events.
  * Adds `Event:or_else(fallback_thunk)` as a biased choice combinator using a “next turn” primitive rather than the old `perform_alt`.
  * Adds `Event:on_abort(f)` and wires it into the same nack machinery as `with_nack`, so abort handlers fire when an arm loses in a choice.
  * Introduces `op.bracket(acquire, release, use)` for RAII-style resource protocols over events (release called on both success and abort).
  * Adds `op.always(value)` and `op.never()` helpers for simple always-ready / never-ready primitives.
  * Extends `op.new_cond` to support abort-only conds (optional `abort_fn`, no `wait_op`), and updates nack signalling logic to drive both `with_nack` and `on_abort`.

* **Library & examples**

  * Switches all internal call sites from `ev:perform()` / `ev:perform_alt()` to `op.perform(ev)` and `ev:or_else(...)`.
  * Updates `fibers.channel`, `fibers.cond`, `fibers.waitgroup`, `fibers.sleep`, `fibers.stream`, `fibers.stream.file`, `fibers.pollio`, `fibers.exec`, `fibers.alarm`, and the cqueues integration example to import `perform`/`choice` locally and use the new API.
  * Adjusts README and basic examples (`choices`, `choices-alt`, `choices-adv`, context examples, lua-http integration) to show the `choice(...)` + `perform(...)` style instead of method-chaining on ops.

* **Tests**

  * Reworks `tests/test_op.lua` into a compact suite aligned with the new API:

    * Uses `perform`, `choice`, `always`, `never`, `or_else`, `with_nack`, and `bracket`.
    * Covers async paths, guards, nested `with_nack`, and bracket abort vs success semantics.
  * Updates `tests/test_stream-file.lua`, `tests/test_waitgroup.lua`, and `tests/test_context.lua` to:

    * Use `perform`/`choice` instead of `:perform()`/`perform_alt()`.
    * Express non-blocking alternatives via `:or_else(...)` instead of `perform_alt`.

* **Docs / formatting**

  * README example updated to the new event style and some minor whitespace tidy-ups.

Behavioural note: this is a public API nudge — consumers should migrate from `op.choice(...):perform[_alt]()` to `perform(choice(...))` / `ev:or_else(...)` over time.

This passes the full test suite.

## Related Issues, Tickets & Documents

None.

## Screenshots/Recordings

Not applicable.

## Manual test

* [x] 👍 yes

## Manual test description

Ran the full test suite locally (including updated op / stream / waitgroup / context tests) and exercised the examples using the new `perform`/`choice` API.

## Added tests?

* [x] 👍 yes

## Added to documentation?

* [x] 📜 README.md

## [optional] Are there any post-deployment tasks we need to perform?

* Downstream users calling `:perform()` / `:perform_alt()` on ops should be guided towards `op.perform(ev)` and `ev:or_else(...)`.
