### PR TITLE
Update primitives

### DIFF
--- a/tests/test_channel.lua
+++ b/tests/test_channel.lua
@@ -62,7 +62,13 @@ local function test_unbounded()
         chan:get()
         blocked = false
     end)
+
+    -- At this point, there is no value available, so get() must have blocked.
     assert(blocked, "get should block")
+
+    -- Now provide a value so the spawned fibre can complete.
+    chan:put(123)
+
     print("Unbounded passed")
 end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

* [x] 🐛 Bug Fix
* [x] 🧑‍💻 Code Refactor
* [x] 🔥 Performance Improvements
* [x] ✅ Test

## Description

Tightens channel rendezvous semantics and makes waitgroups reusable; trims flakiness in tests.

* **channel.lua**

  * Replace ad-hoc GC of stale queue entries with explicit per-op entries and a cancellable flag.
  * Use `on_abort` to mark losing arms cancelled; `pop_active()` skips cancelled entries.
  * Preserve buffered behaviour; simplify fast paths; tidy module header.
  
* **waitgroup.lua**

  * Introduce per-generation condition; allocate on first `add()` from zero, signal on return to zero.
  * `wait_op()` rechecks after `try()` and blocks on the current generation only.
  * Guard against negative counters; no spurious wakeups.
* **tests**

  * `test_channel`: assert `get()` blocks before supplying a value.
  * `test_waitgroup`: add reuse test; shorten sleeps and timings to reduce runtime; adjust assertions accordingly.

Net effect: correct choice-loss cleanup on channels, waitgroups that can be reused safely, fewer retained waiters, and faster, more deterministic tests.

## Manual test

* [x] 👍 yes

## Manual test description

Exercised channel put/get across buffered and unbuffered cases; verified blocked `get()` unblocks on subsequent `put()`. Verified waitgroup reuse across multiple generations; confirmed no deadlocks and expected wakeups.

## Added tests?

* [x] 👍 yes

## Added to documentation?

* [x] 🙅 no documentation needed