### PR TITLE
Prep for step-reversing protocols

### DIFF
--- a/src/fibers/io/fd_backend/core.lua
+++ b/src/fibers/io/fd_backend/core.lua
@@ -77,8 +77,8 @@ end
 ---
 --- Required ops:
 ---   set_nonblock(fd) -> ok:boolean, err|nil
----   read(fd, max)    -> s|nil, err|nil
----   write(fd, s, len)-> n|nil, err|nil
+---   read(fd, max)    -> s|nil, err|nil, want?
+---   write(fd, s, len)-> n|nil, err|nil, want?
 ---   seek(fd, whence, off) -> pos|nil, err|nil
 ---   close(fd)        -> ok:boolean, err|nil
 ---

--- a/src/fibers/io/fd_backend/ffi.lua
+++ b/src/fibers/io/fd_backend/ffi.lua
@@ -167,7 +167,7 @@ local function read_fd(fd, max)
 	if n < 0 then
 		local e = get_errno()
 		if e == EAGAIN or e == EWOULDBLOCK then
-			return nil, nil -- would block
+			return nil, nil, 'rd' -- would block
 		end
 		return nil, strerror(e)
 	end
@@ -191,7 +191,7 @@ local function write_fd(fd, str, len)
 	if n < 0 then
 		local e = get_errno()
 		if e == EAGAIN or e == EWOULDBLOCK then
-			return nil, nil -- would block
+			return nil, nil, 'wr' -- would block
 		end
 		return nil, strerror(e)
 	end

--- a/src/fibers/io/fd_backend/nixio.lua
+++ b/src/fibers/io/fd_backend/nixio.lua
@@ -77,7 +77,7 @@ local function read_fd(fd, max)
 
 	if eno == EAGAIN or eno == EWOULDBLOCK then
 		-- Would block, signal “not ready yet”.
-		return nil, nil
+		return nil, nil, 'rd'
 	end
 
 	if not eno or eno == 0 then
@@ -110,7 +110,7 @@ local function write_fd(fd, str, len)
 
 	if eno == EAGAIN or eno == EWOULDBLOCK then
 		-- Would block.
-		return nil, nil
+		return nil, nil, 'wr'
 	end
 
 	return nil, errno_msg(msg or 'write failed', eno)

--- a/src/fibers/io/fd_backend/posix.lua
+++ b/src/fibers/io/fd_backend/posix.lua
@@ -48,7 +48,7 @@ local function read_fd(fd, max)
 	local s, err, eno = unistd.read(fd, max)
 	if s == nil then
 		if eno == errno.EAGAIN or eno == errno.EWOULDBLOCK then
-			return nil, nil
+			return nil, nil, 'rd'
 		end
 		return nil, errno_msg('read failed', err, eno)
 	end
@@ -59,7 +59,7 @@ local function write_fd(fd, str, _)
 	local n, err, eno = unistd.write(fd, str)
 	if n == nil then
 		if eno == errno.EAGAIN or eno == errno.EWOULDBLOCK then
-			return nil, nil
+			return nil, nil, 'wr'
 		end
 		return nil, errno_msg('write failed', err, eno)
 	end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

* [x] 🍕 Feature

## Description

Extend `wait.waitable` and stream backends to support “direction switching” readiness, where an operation can block on either readability or writability depending on the underlying state machine (eg. TLS WANT_READ/WANT_WRITE).

Changes:

* `wait.waitable`: allow `step()` to return `false, want` (want is any of `'rd'|'wr'|'any'`), pass `want` into `register()`, and re-register on each wake-up based on the latest `want`.
* `wait.waitable`: support `want == 'any'` by registering both read + write waiters and unlinking both on completion/abort.
* `io.stream`: plumb `want` from backend `read_string`/`write_string` into `waitable` and register on the appropriate readiness (`on_readable`/`on_writable`) depending on `want`.
* `fd_backend` (posix/nixio/ffi): return `want` on EAGAIN/EWOULDBLOCK (`'rd'` for reads, `'wr'` for writes).
* Example: enable `fibers.scope` debug traceback capture in `03-scope-finalisers.lua` to aid diagnosis during integration.

Rationale:

* Required for nonblocking TLS handshakes and shutdown where “read” may require writability and “write” may require readability.
* Preserves existing behaviour for simple fd-backed streams while making readiness waiting more expressive and predictable.

## Manual test

* [x] 👍 yes

## Manual test description

* Ran existing examples locally to confirm normal scheduling and finaliser behaviour remains intact.
* Verified stream read/write against nonblocking fds still progresses correctly; EAGAIN/EWOULDBLOCK now yields a `want` value and re-registers appropriately.
* Sanity-checked `want == 'any'` handling by ensuring both registrations are created and unlinked as expected.

## Added tests?

* [x] 🙅 no, because they aren't needed

## Added to documentation?

* [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?

Nope